### PR TITLE
Generate AppImage on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ notifications:
     on_start: never     # options: [always|never|change] default: always
 branches:
   only:
-    - master 
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage 
-  - curl --upload-file ./fastQt*.AppImage https://transfer.sh/fastQt-git.$(git rev-parse --short HEAD)-x86_64.AppImage 
+  - curl --upload-file ./FastQt*.AppImage https://transfer.sh/FastQt-git.$(git rev-parse --short HEAD)-x86_64.AppImage 
 
 # For gitter 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,15 @@ script:
   - make 
   - sudo make install
   - cd ../..
-  - /opt/qt58/bin/qmake 
+  - /opt/qt58/bin/qmake PREFIX=/usr
   - make 
   - # Generate AppImage
   - sudo apt-get -y install checkinstall
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
-  - mkdir appdir ; cd appdir
+  - mkdir -p appdir/usr/bin ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ./usr/share/icons/hicolor/48x48/apps/fastqt.png .
+  - cp ./usr/share/applications/fastqt.desktop .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,18 @@ script:
   - cd ../..
   - /opt/qt58/bin/qmake 
   - make 
+  - # Generate AppImage
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage 
+  - curl --upload-file ./fastQt*.AppImage https://transfer.sh/fastQt-git.$(git rev-parse --short HEAD)-x86_64.AppImage 
 
 # For gitter 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir -p appdir/usr/bin ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - mv ./usr/local/bin/* ./usr/bin/ # Why is this needed despite PREFIX=/usr? Bug?
   - cp ./usr/share/icons/hicolor/48x48/apps/fastqt.png .
   - cp ./usr/share/applications/fastqt.desktop .
   - cd .. 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
-branches:
-  only:
-    - master
+
+# Temporarily disabled so that AppImage generation can be tested
+# branches:
+#   only:
+#    - master

--- a/fastqt.desktop
+++ b/fastqt.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name=FastQt
 Comment=A quality control tool for high throughput genomics sequence data. 
 Exec=fastqt %F
-Icon=fastqt.png
-Terminal=False
-Categories=Science;Biology;Qt
+Icon=fastqt
+Terminal=false
+Categories=Science;Biology;Qt;


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

An example can be downloaded from https://transfer.sh/alWaa/fastqt-git.8704cc6-x86-64.appimage.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.